### PR TITLE
[CI] Update toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}
+    name: Test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: stable
           override: true
 
       - name: Run tests
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: stable
           override: true
       - name: Add target
         run: rustup target add ${{ matrix.target }}
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: stable
           override: true
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
@@ -61,7 +61,7 @@ jobs:
           args: --all --benches
 
   clippy:
-    name: Clippy (1.51.0)
+    name: Clippy
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -69,12 +69,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-          toolchain: 1.51.0
+          toolchain: stable
           override: true
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.51.0)
+          name: Clippy
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets -- -D warnings
 
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: stable
           override: true
       # Ensure all code has been formatted with rustfmt
       - run: rustup component add rustfmt


### PR DESCRIPTION
There was a weird bug with wasm-bindgen in the CI.
We were installing the latest toolchain and then downgrading it back to 1.51.0. This removes the latter part.