### PR TITLE
API + faster mixed addition

### DIFF
--- a/benches/curve_projective.rs
+++ b/benches/curve_projective.rs
@@ -42,6 +42,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         bench.iter(|| black_box(p) + black_box(p2_affine))
     });
 
+    c.bench_function("Projective unchecked mixed addition", |bench| {
+        bench.iter(|| black_box(p).add_mixed_unchecked(black_box(&p2_affine)))
+    });
+
     c.bench_function("Projective subtraction", |bench| {
         bench.iter(|| black_box(p) - black_box(p2))
     });

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,8 +6,39 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{BasePointTable, NafLookupTable, ProjectivePoint, Scalar};
+use crate::{AffinePoint, BasePointTable, NafLookupTable, ProjectivePoint};
+use crate::{Fp, Fp6, Scalar};
+
 use core::ops::Mul;
+use subtle::Choice;
+
+/// A fixed shift point of the curve in projective coordinates
+/// The point has been generated from the Simplified Shallue-van
+/// de Woestijne-Ulas method for hashing to elliptic curves in
+/// Short Weierstrass form, applied on the integer value of the
+/// binary encoding of the string "Cheetah - Shift point".
+///
+/// See https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve
+/// for more.
+pub const SHIFT_POINT: ProjectivePoint = ProjectivePoint {
+    x: Fp6 {
+        c0: Fp(0xab95fb0d188ff2b1),
+        c1: Fp(0xf38263a8c954493e),
+        c2: Fp(0x1bc968d6739028b7),
+        c3: Fp(0x4f67684fe6b27d1f),
+        c4: Fp(0x6504f8bbba9077b4),
+        c5: Fp(0x860838116d76e545),
+    },
+    y: Fp6 {
+        c0: Fp(0x56988918d5b02cf3),
+        c1: Fp(0xc9fe3ef9d7652c54),
+        c2: Fp(0x4923e90c4d6f4538),
+        c3: Fp(0xc747ac3f82369f27),
+        c4: Fp(0x6e74c106972c71f5),
+        c5: Fp(0xcf190938f1c64bb5),
+    },
+    z: Fp6::one(),
+};
 
 lazy_static! {
     /// A hardcoded `BasePointTable` for the generator of the Cheetah
@@ -20,6 +51,51 @@ lazy_static! {
     /// multiplications.
     pub static ref ODD_MULTIPLES_BASEPOINT: NafLookupTable::<64> =
         NafLookupTable::<64>::from(&ProjectivePoint::generator());
+
+    /// The opposite of 2^4.SHIFT_POINT. This is used when multiplying a
+    /// `BasePointTable` with a `Scalar` for faster scalar multiplication.
+    pub static ref MINUS_SHIFT_POINT_POW_4: AffinePoint = AffinePoint {
+        x: Fp6 {
+            c0: Fp(0x59f135aa8369eea0),
+            c1: Fp(0xdfcadde02ca0362b),
+            c2: Fp(0x99e498bacad59dc0),
+            c3: Fp(0xc0ae607c0e4289fe),
+            c4: Fp(0xa3c9733bbefe411c),
+            c5: Fp(0x2c0e26555061fbbf),
+            },
+        y: Fp6 {
+            c0: Fp(0xfb19a0cfab8e245c),
+            c1: Fp(0x23f1f9b307ac72e1),
+            c2: Fp(0xb9d43296c72c79f2),
+            c3: Fp(0xa430f22e5903080c),
+            c4: Fp(0x2ca860527297557e),
+            c5: Fp(0x9e05765dcd66172c),
+        },
+        infinity: Choice::from(0u8),
+    };
+
+    /// The opposite of 2^256.SHIFT_POINT. This is used when multiplying
+    /// an `AffinePoint` or a `ProjectivePoint` with a `Scalar` for faster
+    /// scalar multiplication.
+    pub static ref MINUS_SHIFT_POINT_POW_256: AffinePoint = AffinePoint {
+        x: Fp6 {
+            c0: Fp(0xbf055af286583ccc),
+            c1: Fp(0xee33e2330c725cdd),
+            c2: Fp(0xa1bdadd9ea138f24),
+            c3: Fp(0xf97d628d13c4e145),
+            c4: Fp(0xb6389323811c4747),
+            c5: Fp(0xed92b921e0c7e575),
+        },
+        y: Fp6 {
+            c0: Fp(0xcad959f8181d46a4),
+            c1: Fp(0x2d434d5931a7c485),
+            c2: Fp(0x39483eba519e8d5f),
+            c3: Fp(0xeadcd00fc1d23ee),
+            c4: Fp(0x6f5350dfabc6b254),
+            c5: Fp(0x286e25dbcc086611),
+        },
+        infinity: Choice::from(0u8),
+    };
 }
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a BASEPOINT_TABLE {

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -14,6 +14,7 @@ use core::{
     borrow::Borrow,
     cmp::Ordering,
     fmt,
+    hash::{Hash, Hasher},
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -72,6 +73,13 @@ impl zeroize::DefaultIsZeroes for AffinePoint {}
 impl fmt::Display for AffinePoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl Hash for AffinePoint {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.x.hash(hasher);
+        self.y.hash(hasher);
     }
 }
 
@@ -418,6 +426,12 @@ impl zeroize::DefaultIsZeroes for ProjectivePoint {}
 impl fmt::Display for ProjectivePoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl Hash for ProjectivePoint {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.to_affine().hash(hasher);
     }
 }
 

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -477,11 +477,7 @@ impl<'a> Neg for &'a ProjectivePoint {
 
     #[inline]
     fn neg(self) -> ProjectivePoint {
-        ProjectivePoint {
-            x: self.x,
-            y: -self.y,
-            z: self.z,
-        }
+        self.neg()
     }
 }
 
@@ -770,6 +766,16 @@ impl ProjectivePoint {
         ProjectivePoint::conditional_select(&tmp, &ProjectivePoint::identity(), self.is_identity())
     }
 
+    /// Computes the negation of a point in projective coordinates
+    #[inline]
+    pub const fn neg(&self) -> Self {
+        Self {
+            x: self.x,
+            y: (&self.y).neg(),
+            z: self.z,
+        }
+    }
+
     /// Adds this point to another point.
     pub const fn add(&self, rhs: &ProjectivePoint) -> ProjectivePoint {
         // Algorithm 1, https://eprint.iacr.org/2015/1060.pdf
@@ -935,10 +941,7 @@ impl ProjectivePoint {
 
         let mut acc = ProjectivePoint::from(&table.get_point(digits[63]));
         for i in (0..63).rev() {
-            acc = acc.double();
-            acc = acc.double();
-            acc = acc.double();
-            acc = acc.double();
+            acc = acc.double_multi(4);
             acc += table.get_point(digits[i]);
         }
 
@@ -994,10 +997,7 @@ impl ProjectivePoint {
         let mut acc = ProjectivePoint::from(&table_lhs.get_point(digits_lhs[63]));
         acc += table_rhs.get_point(digits_rhs[63]);
         for i in (0..63).rev() {
-            acc = acc.double();
-            acc = acc.double();
-            acc = acc.double();
-            acc = acc.double();
+            acc = acc.double_multi(4);
             acc += table_lhs.get_point(digits_lhs[i]);
             acc += table_rhs.get_point(digits_rhs[i]);
         }
@@ -1748,7 +1748,7 @@ mod tests {
             assert!(c == ProjectivePoint::generator());
         }
         {
-            let a = ProjectivePoint::generator().double().double(); // 4P
+            let a = ProjectivePoint::generator().double_multi(2); // 4P
             let b = ProjectivePoint::generator().double(); // 2P
             let c = a + b;
 
@@ -1822,7 +1822,7 @@ mod tests {
             assert!(c == ProjectivePoint::generator());
         }
         {
-            let a = ProjectivePoint::generator().double().double(); // 4P
+            let a = ProjectivePoint::generator().double_multi(2); // 4P
             let b = ProjectivePoint::generator().double(); // 2P
             let c = a + b;
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -12,6 +12,7 @@
 use core::{
     borrow::Borrow,
     fmt::{self, Debug, Display, Formatter},
+    hash::{Hash, Hasher},
     iter::Sum,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -65,6 +66,12 @@ impl Debug for Fp {
 impl Display for Fp {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl Hash for Fp {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.0.hash(hasher);
     }
 }
 

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -12,6 +12,7 @@
 use core::{
     borrow::Borrow,
     fmt::{self, Formatter},
+    hash::{Hash, Hasher},
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -80,6 +81,17 @@ impl fmt::Debug for Fp6 {
 impl Default for Fp6 {
     fn default() -> Self {
         Self::zero()
+    }
+}
+
+impl Hash for Fp6 {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.c0.hash(hasher);
+        self.c1.hash(hasher);
+        self.c2.hash(hasher);
+        self.c3.hash(hasher);
+        self.c4.hash(hasher);
+        self.c5.hash(hasher);
     }
 }
 

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -694,6 +694,19 @@ impl Fp6 {
         }
     }
 
+    /// Computes the triple of a field element
+    #[inline]
+    pub const fn triple(&self) -> Self {
+        Self {
+            c0: (&self.c0).triple(),
+            c1: (&self.c1).triple(),
+            c2: (&self.c2).triple(),
+            c3: (&self.c3).triple(),
+            c4: (&self.c4).triple(),
+            c5: (&self.c5).triple(),
+        }
+    }
+
     /// Computes the summation of two field elements
     #[inline]
     pub const fn add(&self, rhs: &Self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,9 @@ pub use scalar::Scalar;
 pub use fp::Fp;
 pub use fp6::Fp6;
 
-pub use constants::BASEPOINT_TABLE;
+pub use constants::{
+    BASEPOINT_TABLE, MINUS_SHIFT_POINT_POW_256, MINUS_SHIFT_POINT_POW_4, SHIFT_POINT,
+};
 pub use lookup::{BasePointTable, LookupTable};
 pub use naf_lookup::NafLookupTable;
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -11,6 +11,7 @@
 //! Adapted from https://github.com/RustCrypto/elliptic-curves
 
 use crate::{AffinePoint, ProjectivePoint, Scalar};
+use crate::{MINUS_SHIFT_POINT_POW_4, SHIFT_POINT};
 
 use core::ops::Mul;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -181,19 +182,19 @@ impl BasePointTable {
         let a = Scalar::bytes_to_radix_16(scalar);
 
         let tables = &self.0;
-        let mut acc = ProjectivePoint::identity();
+        let mut acc = SHIFT_POINT;
 
         for i in (0..64).filter(|x| x % 2 == 1) {
-            acc += &tables[i / 2].get_point(a[i]);
+            acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
         acc = acc.double_multi(4);
 
         for i in (0..64).filter(|x| x % 2 == 0) {
-            acc += &tables[i / 2].get_point(a[i]);
+            acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc
+        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_POW_4)
     }
 
     /// Performs a mixed scalar multiplication from `by`
@@ -208,19 +209,19 @@ impl BasePointTable {
         let a = Scalar::bytes_to_radix_16(scalar);
 
         let tables = &self.0;
-        let mut acc = ProjectivePoint::identity();
+        let mut acc = SHIFT_POINT;
 
         for i in (0..64).filter(|x| x % 2 == 1) {
-            acc += &tables[i / 2].get_point_vartime(a[i]);
+            acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
         acc = acc.double_multi(4);
 
         for i in (0..64).filter(|x| x % 2 == 0) {
-            acc += &tables[i / 2].get_point_vartime(a[i]);
+            acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc
+        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_POW_4)
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -14,6 +14,7 @@ use core::{
     borrow::Borrow,
     convert::{TryFrom, TryInto},
     fmt::{self, Debug, Display, Formatter},
+    hash::{Hash, Hasher},
     iter::Sum,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -124,6 +125,12 @@ impl Debug for Scalar {
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl Hash for Scalar {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.0.hash(hasher);
     }
 }
 


### PR DESCRIPTION
This PR implements some additional methods and traits for existing types, needed for changes on the Schnorr signature repo, and relies for some scalar multiplication methods on faster unchecked mixed addition. To prevent falling on an edgecase, the accumulators start on a "shift" point that is removed at the end. The gains are between 4% and 8.5%.