### PR TITLE
Unchecked doubling

### DIFF
--- a/benches/curve_projective.rs
+++ b/benches/curve_projective.rs
@@ -54,6 +54,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         bench.iter(|| black_box(p).double())
     });
 
+    c.bench_function("Projective unchecked doubling", |bench| {
+        bench.iter(|| black_box(p).double_unchecked())
+    });
+
     c.bench_function(
         "Projective scalar multiplication (variable base)",
         |bench| bench.iter(|| ProjectivePoint::multiply(black_box(&p), black_box(&pow))),

--- a/benches/fp.rs
+++ b/benches/fp.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use rand_core::OsRng;
+use rand_core::RngCore;
 
 #[macro_use]
 extern crate criterion;
@@ -25,12 +26,17 @@ fn criterion_benchmark(c: &mut Criterion) {
     let x_bytes = x.to_bytes();
     let y = Fp::random(&mut rng);
     let pow = y.output_internal();
+    let y_32 = rng.next_u32();
 
     c.bench_function("Fp add", |bench| bench.iter(|| black_box(x) + black_box(y)));
 
     c.bench_function("Fp sub", |bench| bench.iter(|| black_box(x) - black_box(y)));
 
     c.bench_function("Fp double", |bench| bench.iter(|| black_box(x).double()));
+
+    c.bench_function("Fp mul u32", |bench| {
+        bench.iter(|| black_box(x).mul_by_u32(black_box(y_32)))
+    });
 
     c.bench_function("Fp mul", |bench| bench.iter(|| black_box(x) * black_box(y)));
 

--- a/benches/fp6.rs
+++ b/benches/fp6.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use rand_core::OsRng;
+use rand_core::RngCore;
 
 #[macro_use]
 extern crate criterion;
@@ -25,6 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let x_bytes = x.to_bytes();
     let y = Fp6::random(&mut rng);
     let pow = y.output_internal();
+    let y32 = rng.next_u32();
 
     c.bench_function("Fp6 add", |bench| {
         bench.iter(|| black_box(x) + black_box(y))
@@ -35,6 +37,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Fp6 double", |bench| bench.iter(|| black_box(x).double()));
+
+    c.bench_function("Fp6 mul u32", |bench| {
+        bench.iter(|| black_box(x).mul_by_u32(black_box(y32)))
+    });
 
     c.bench_function("Fp6 mul", |bench| {
         bench.iter(|| black_box(x) * black_box(y))

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,7 +10,6 @@ use crate::{AffinePoint, BasePointTable, NafLookupTable, ProjectivePoint};
 use crate::{Fp, Fp6, Scalar};
 
 use core::ops::Mul;
-use subtle::Choice;
 
 /// A fixed shift point of the curve in projective coordinates
 /// The point has been generated from the Simplified Shallue-van
@@ -52,50 +51,24 @@ lazy_static! {
     pub static ref ODD_MULTIPLES_BASEPOINT: NafLookupTable::<64> =
         NafLookupTable::<64>::from(&ProjectivePoint::generator());
 
-    /// The opposite of 2^4.SHIFT_POINT. This is used when multiplying a
-    /// `BasePointTable` with a `Scalar` for faster scalar multiplication.
-    pub static ref MINUS_SHIFT_POINT_POW_4: AffinePoint = AffinePoint {
-        x: Fp6 {
-            c0: Fp(0x59f135aa8369eea0),
-            c1: Fp(0xdfcadde02ca0362b),
-            c2: Fp(0x99e498bacad59dc0),
-            c3: Fp(0xc0ae607c0e4289fe),
-            c4: Fp(0xa3c9733bbefe411c),
-            c5: Fp(0x2c0e26555061fbbf),
-            },
-        y: Fp6 {
-            c0: Fp(0xfb19a0cfab8e245c),
-            c1: Fp(0x23f1f9b307ac72e1),
-            c2: Fp(0xb9d43296c72c79f2),
-            c3: Fp(0xa430f22e5903080c),
-            c4: Fp(0x2ca860527297557e),
-            c5: Fp(0x9e05765dcd66172c),
-        },
-        infinity: Choice::from(0u8),
-    };
-
-    /// The opposite of 2^256.SHIFT_POINT. This is used when multiplying
-    /// an `AffinePoint` or a `ProjectivePoint` with a `Scalar` for faster
+    /// An array of points corresponding to -2^i.SHIFT_POINT, for i ranging
+    /// from 0 to 256 included. This is used when multiplying an `AffinePoint`,
+    /// a `ProjectivePoint` or a `BasePointTable` with a `Scalar` for faster
     /// scalar multiplication.
-    pub static ref MINUS_SHIFT_POINT_POW_256: AffinePoint = AffinePoint {
-        x: Fp6 {
-            c0: Fp(0xbf055af286583ccc),
-            c1: Fp(0xee33e2330c725cdd),
-            c2: Fp(0xa1bdadd9ea138f24),
-            c3: Fp(0xf97d628d13c4e145),
-            c4: Fp(0xb6389323811c4747),
-            c5: Fp(0xed92b921e0c7e575),
-        },
-        y: Fp6 {
-            c0: Fp(0xcad959f8181d46a4),
-            c1: Fp(0x2d434d5931a7c485),
-            c2: Fp(0x39483eba519e8d5f),
-            c3: Fp(0xeadcd00fc1d23ee),
-            c4: Fp(0x6f5350dfabc6b254),
-            c5: Fp(0x286e25dbcc086611),
-        },
-        infinity: Choice::from(0u8),
-    };
+    pub static ref MINUS_SHIFT_POINT_ARRAY: [AffinePoint; 257] =
+        generate_opposite_powers(&SHIFT_POINT);
+}
+
+fn generate_opposite_powers(point: &ProjectivePoint) -> [AffinePoint; 257] {
+    let mut array = [point.neg(); 257];
+    for i in 1..257 {
+        array[i] = array[i - 1].double();
+    }
+
+    let mut array_affine = [AffinePoint::identity(); 257];
+    ProjectivePoint::batch_normalize(&array, &mut array_affine);
+
+    array_affine
 }
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a BASEPOINT_TABLE {

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -760,8 +760,7 @@ impl ProjectivePoint {
         let t3 = (&self.y).mul(&b);
         let c = (&t3).mul(&self.x);
 
-        let d = c.double();
-        let c4 = d.double();
+        let c4 = c.mul_by_u32(4);
         let d = c4.double();
 
         let t = a.square();
@@ -774,17 +773,13 @@ impl ProjectivePoint {
         let y3 = (&a).mul(&y3);
         let t3 = t3.square();
 
-        let t3 = t3.double();
-        let t3 = t3.double();
-        let t3 = t3.double();
+        let t3 = t3.mul_by_u32(8);
 
         let y3 = (&y3).sub(&t3);
         let z3 = b.square();
         let z3 = (&z3).mul(&b);
 
-        let z3 = z3.double();
-        let z3 = z3.double();
-        let z3 = z3.double();
+        let z3 = z3.mul_by_u32(8);
 
         let tmp = ProjectivePoint {
             x: x3,
@@ -802,7 +797,7 @@ impl ProjectivePoint {
     /// **This is dangerous to call unless you know that the point to be doubled
     /// is not the identity point, otherwise, API invariants may be broken.**
     /// Please consider using `double()` instead.
-    pub fn double_unchecked(&self) -> ProjectivePoint {
+    pub const fn double_unchecked(&self) -> ProjectivePoint {
         // Use formula given in Handbook of Elliptic and Hyperelliptic Curve Cryptography, part 13.2
 
         let x2 = self.x.square();
@@ -828,18 +823,16 @@ impl ProjectivePoint {
 
         let y3 = (&c4).sub(&d);
         let y3 = (&a).mul(&y3);
-        let t3 = t3.square();
 
         let t3 = t3.double();
-        let t3 = t3.double();
+        let t3 = t3.square();
         let t3 = t3.double();
 
         let y3 = (&y3).sub(&t3);
-        let z3 = b.square();
-        let z3 = (&z3).mul(&b);
 
-        let z3 = z3.double();
-        let z3 = z3.double();
+        let z3 = b.double();
+        let z3 = z3.square();
+        let z3 = (&z3).mul(&b);
         let z3 = z3.double();
 
         ProjectivePoint {

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -814,6 +814,17 @@ mod tests {
     }
 
     #[test]
+    fn test_multiplication_by_u32() {
+        let mut rng = OsRng;
+
+        for _ in 0..100 {
+            let a = Fp::random(&mut rng);
+            let b = rng.next_u32();
+            assert_eq!(a.mul_by_u32(b), a * Fp::from(b));
+        }
+    }
+
+    #[test]
     fn test_division() {
         let mut rng = OsRng;
         let scale = Fp::random(&mut rng);

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -363,6 +363,26 @@ impl Fp6 {
     }
 
     #[inline]
+    /// Computes the multiplication of an Fp6 element with a u32
+    pub const fn mul_by_u32(&self, other: u32) -> Fp6 {
+        let c0 = (&self.c0).mul_by_u32(other);
+        let c1 = (&self.c1).mul_by_u32(other);
+        let c2 = (&self.c2).mul_by_u32(other);
+        let c3 = (&self.c3).mul_by_u32(other);
+        let c4 = (&self.c4).mul_by_u32(other);
+        let c5 = (&self.c5).mul_by_u32(other);
+
+        Self {
+            c0,
+            c1,
+            c2,
+            c3,
+            c4,
+            c5,
+        }
+    }
+
+    #[inline]
     /// Computes the multiplication of an Fp6 element with an Fp element
     pub const fn mul_by_fp(&self, other: &Fp) -> Fp6 {
         let c0 = (&self.c0).mul(other);
@@ -1350,6 +1370,17 @@ mod tests {
         };
 
         assert_eq!(a * b, c);
+    }
+
+    #[test]
+    fn test_multiplication_by_u32() {
+        let mut rng = OsRng;
+
+        for _ in 0..100 {
+            let a = Fp6::random(&mut rng);
+            let b = rng.next_u32();
+            assert_eq!(a.mul_by_u32(b), a * Fp6::from(b));
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,7 @@ pub use scalar::Scalar;
 pub use fp::Fp;
 pub use fp6::Fp6;
 
-pub use constants::{
-    BASEPOINT_TABLE, MINUS_SHIFT_POINT_POW_256, MINUS_SHIFT_POINT_POW_4, SHIFT_POINT,
-};
+pub use constants::{BASEPOINT_TABLE, MINUS_SHIFT_POINT_ARRAY, SHIFT_POINT};
 pub use lookup::{BasePointTable, LookupTable};
 pub use naf_lookup::NafLookupTable;
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -11,7 +11,7 @@
 //! Adapted from https://github.com/RustCrypto/elliptic-curves
 
 use crate::{AffinePoint, ProjectivePoint, Scalar};
-use crate::{MINUS_SHIFT_POINT_POW_4, SHIFT_POINT};
+use crate::{MINUS_SHIFT_POINT_ARRAY, SHIFT_POINT};
 
 use core::ops::Mul;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -194,7 +194,7 @@ impl BasePointTable {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_POW_4)
+        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_ARRAY[4])
     }
 
     /// Performs a mixed scalar multiplication from `by`
@@ -221,7 +221,7 @@ impl BasePointTable {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_POW_4)
+        acc.add_mixed_unchecked(&MINUS_SHIFT_POINT_ARRAY[4])
     }
 }
 

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -101,12 +101,8 @@ impl<const N: usize> LookupTable<N> {
         let xabs = (x + xmask) ^ xmask;
 
         // Get an array element
-        let mut t = AffinePoint::identity();
-        for j in 1..N + 1 {
-            if xabs as usize == j {
-                t = self.0[j - 1];
-            }
-        }
+        let mut t = self.0[xabs as usize - 1];
+
         // Now t == |x| * p.
 
         if xmask & 1 == 1 {

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -188,7 +188,7 @@ impl BasePointTable {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc = acc.double_multi(4);
+        acc = acc.double_multi_unchecked(4);
 
         for i in (0..64).filter(|x| x % 2 == 0) {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
@@ -215,7 +215,7 @@ impl BasePointTable {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));
         }
 
-        acc = acc.double_multi(4);
+        acc = acc.double_multi_unchecked(4);
 
         for i in (0..64).filter(|x| x % 2 == 0) {
             acc = acc.add_mixed_unchecked(&tables[i / 2].get_point(a[i]));


### PR DESCRIPTION
This PR is a follow-up of #24 for faster scalar multiplication, by using incomplete doubling formula for scalar multiplication algorithms shifted by a random point. It also extends the shifting approach to NAF-lookup based algorithms.