### PR TITLE
Fix/debug format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI checks
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   test:

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -305,6 +305,27 @@ mod tests {
     fn test_debug() {
         assert_eq!(format!("{:?}", Fp3::zero()), "0");
         assert_eq!(format!("{:?}", Fp3::one()), "1");
+
+        let a = Fp3 {
+            a0: Fp::new(0),
+            a1: Fp::new(0),
+            a2: Fp::new(7)
+        };
+        assert_eq!(format!("{:?}", a), "7u^2");
+
+        let b = Fp3 {
+            a0: Fp::new(1),
+            a1: Fp::new(0),
+            a2: Fp::new(11)
+        };
+        assert_eq!(format!("{:?}", b), "1 + 11u^2");
+
+        let c = Fp3 {
+            a0: Fp::new(1),
+            a1: Fp::new(2),
+            a2: Fp::new(1)
+        };
+        assert_eq!(format!("{:?}", c), "1 + 2u + u^2");
     }
     // BASIC ALGEBRA
     // ================================================================================================

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -42,6 +42,10 @@ pub(crate) struct Fp3 {
 
 impl fmt::Debug for Fp3 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        if *self == Fp3::zero() {
+            return write!(f, "0"); // Handle the case where all coefficients are zero
+        }
+
         let coeffs = [self.a0, self.a1, self.a2];
 
         let format_term = |coef: Fp, degree: usize| -> String {
@@ -81,10 +85,6 @@ impl fmt::Debug for Fp3 {
             })
             .collect::<Vec<String>>()
             .join(" + ");
-
-        if *self == Fp3::zero() {
-            return write!(f, "0"); // Handle the case where all coefficients are zero
-        }
 
         write!(f, "{}", elem_rep)?;
 

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -12,6 +12,13 @@
 
 use core::fmt::{self, Formatter};
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::fp::reduce_u96;

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -43,34 +43,42 @@ pub(crate) struct Fp3 {
 impl fmt::Debug for Fp3 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let coeffs = [self.a0, self.a1, self.a2];
-        let mut first_term = true;
-        for i in 0..3 {
-            if coeffs[i] == Fp::zero() {
-                continue;
-            }
 
-            if !first_term {
-                write!(f, " + ")?;
-            }
-
-            if coeffs[i] == Fp::one() && i > 0usize {
-                write!(f, "u")?; // Display "u" instead of "1u"
+        let format_term = |coef: Fp, degree: usize| -> String {
+            if coef == Fp::one() && degree > 0 {
+                let exp = if degree > 1 {
+                    format!("^{}", degree)
+                } else {
+                    "".to_string()
+                };
+                format!("u{}", exp)
             } else {
-                write!(f, "{}", coeffs[i])?;
-                if i > 0 {
-                    write!(f, "u")?;
+                let exp =  if degree > 0 {
+                    format!("u{}", if degree > 1 { format!("^{}", degree) } else { "".to_string() })
+                } else {
+                    "".to_string()
+                };
+                format!("{}{}", coef, exp)
+            }
+        };
+
+        let elem_rep = coeffs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &coef)| {
+                if coef == Fp::zero() {
+                    None
+                } else {
+                    Some(format_term(coef, i))
                 }
-            }
+            })
+            .collect::<Vec<String>>()
+            .join(" + ");
 
-            if i > 1 {
-                write!(f, "^{}", i)?;
-            }
-
-            first_term = false;
-        }
-
-        if first_term {
+        if elem_rep.is_empty() {
             write!(f, "0")?; // Handle the case where all coefficients are zero
+        } else {
+            write!(f, "{}", elem_rep)?;
         }
 
         Ok(())
@@ -281,15 +289,6 @@ mod tests {
     use rand_core::{OsRng, RngCore};
 
     impl Fp3 {
-        /// Creates a new Fp3 element
-        fn new(coeffs: [u64; 3]) -> Self {
-            Self {
-                a0: Fp::new(coeffs[0]),
-                a1: Fp::new(coeffs[1]),
-                a2: Fp::new(coeffs[2])
-            }
-        }
-
         /// Generates a random canonical element
         fn random(mut rng: impl RngCore) -> Self {
             Self {
@@ -304,21 +303,8 @@ mod tests {
     // ================================================================================================
     #[test]
     fn test_debug() {
-        assert_eq!(format!("{:?}", Fp3::zero()), "");
+        assert_eq!(format!("{:?}", Fp3::zero()), "0");
         assert_eq!(format!("{:?}", Fp3::one()), "1");
-        assert_eq!(
-            format!("{:?}", Fp3::new([1, 2, 3])),
-            "1 + 2u + 3u^2"
-        );
-        assert_eq!(
-            format!("{:?}", Fp3::new([0, 1, 0])),
-            "u"
-        );
-        assert_eq!(format!("{:?}", Fp3::new([0, 0, 5])), "5u^2");
-
-        assert_eq!(format!("{:?}", Fp3::new([0, 5, 7])), "5u + 7u^2");
-        assert_eq!(format!("{:?}", Fp3::new([1, 1, 1])), "1 + u + u^2")
-
     }
     // BASIC ALGEBRA
     // ================================================================================================

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -75,11 +75,11 @@ impl fmt::Debug for Fp3 {
             .collect::<Vec<String>>()
             .join(" + ");
 
-        if elem_rep.is_empty() {
-            write!(f, "0")?; // Handle the case where all coefficients are zero
-        } else {
-            write!(f, "{}", elem_rep)?;
-        }
+        if *self == Fp3::zero() {
+            return write!(f, "0"); // Handle the case where all coefficients are zero
+        } 
+        
+        write!(f, "{}", elem_rep)?;
 
         Ok(())
     }

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -70,7 +70,7 @@ impl fmt::Debug for Fp3 {
         }
 
         if first_term {
-            write!(f, "")?; // Handle the case where all coefficients are zero
+            write!(f, "0")?; // Handle the case where all coefficients are zero
         }
 
         Ok(())

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -53,8 +53,15 @@ impl fmt::Debug for Fp3 {
                 };
                 format!("u{}", exp)
             } else {
-                let exp =  if degree > 0 {
-                    format!("u{}", if degree > 1 { format!("^{}", degree) } else { "".to_string() })
+                let exp = if degree > 0 {
+                    format!(
+                        "u{}",
+                        if degree > 1 {
+                            format!("^{}", degree)
+                        } else {
+                            "".to_string()
+                        }
+                    )
                 } else {
                     "".to_string()
                 };
@@ -77,8 +84,8 @@ impl fmt::Debug for Fp3 {
 
         if *self == Fp3::zero() {
             return write!(f, "0"); // Handle the case where all coefficients are zero
-        } 
-        
+        }
+
         write!(f, "{}", elem_rep)?;
 
         Ok(())
@@ -309,21 +316,21 @@ mod tests {
         let a = Fp3 {
             a0: Fp::new(0),
             a1: Fp::new(0),
-            a2: Fp::new(7)
+            a2: Fp::new(7),
         };
         assert_eq!(format!("{:?}", a), "7u^2");
 
         let b = Fp3 {
             a0: Fp::new(1),
             a1: Fp::new(0),
-            a2: Fp::new(11)
+            a2: Fp::new(11),
         };
         assert_eq!(format!("{:?}", b), "1 + 11u^2");
 
         let c = Fp3 {
             a0: Fp::new(1),
             a1: Fp::new(2),
-            a2: Fp::new(1)
+            a2: Fp::new(1),
         };
         assert_eq!(format!("{:?}", c), "1 + 2u + u^2");
     }

--- a/src/fp3.rs
+++ b/src/fp3.rs
@@ -488,6 +488,4 @@ mod tests {
             TWO_ADIC_ROOT_OF_UNITY_P3.exp_vartime(&[two_pow_32 - 1, 0, 0,])
         );
     }
-
-
 }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -67,8 +67,15 @@ impl fmt::Debug for Fp6 {
                 };
                 format!("u{}", exp)
             } else {
-                let exp =  if degree > 0 {
-                    format!("u{}", if degree > 1 { format!("^{}", degree) } else { "".to_string() })
+                let exp = if degree > 0 {
+                    format!(
+                        "u{}",
+                        if degree > 1 {
+                            format!("^{}", degree)
+                        } else {
+                            "".to_string()
+                        }
+                    )
                 } else {
                     "".to_string()
                 };
@@ -92,7 +99,7 @@ impl fmt::Debug for Fp6 {
         if self.is_zero().into() {
             return write!(f, "0"); // Handle the case where all coefficients are zero
         }
-        
+
         write!(f, "{}", elem_rep)?;
 
         Ok(())
@@ -1308,7 +1315,10 @@ mod tests {
         let a = Fp6::one().neg();
         assert_eq!(format!("{:?}", a), "18446744069414584320");
 
-        assert_eq!(format!("{:?}", Fp6::new([1, 1, 1, 1, 1, 1])), "1 + u + u^2 + u^3 + u^4 + u^5")
+        assert_eq!(
+            format!("{:?}", Fp6::new([1, 1, 1, 1, 1, 1])),
+            "1 + u + u^2 + u^3 + u^4 + u^5"
+        )
     }
 
     #[test]

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -57,29 +57,34 @@ pub struct Fp6 {
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let coeffs = [self.c0, self.c1, self.c2, self.c3, self.c4, self.c5];
-
+        let mut first_term = true;
         for i in 0..6 {
             if coeffs[i] == Fp::zero() {
                 continue;
             }
 
-            let coefficient = format!("{}", coeffs[i]);
+            if !first_term {
+                write!(f, " + ")?;
+            }
 
-            if i >= 1 {
-                if coeffs[i] != Fp::one() {
-                    write!(f, " + {}", coefficient)?
-                }
-
-                if i >= 1 {
+            if coeffs[i] == Fp::one() && i > 0usize {
+                write!(f, "u")?; // Display "u" instead of "1u"
+            } else {
+                write!(f, "{}", coeffs[i])?;
+                if i > 0 {
                     write!(f, "u")?;
                 }
-
-                if i >= 2 {
-                    write!(f, "^{}", i)?;
-                }
-            } else {
-                write!(f, "{coefficient}")?;
             }
+
+            if i > 1 {
+                write!(f, "^{}", i)?;
+            }
+
+            first_term = false;
+        }
+
+        if first_term {
+            write!(f, "")?; // Handle the case where all coefficients are zero
         }
 
         Ok(())
@@ -1290,9 +1295,12 @@ mod tests {
             format!("{:?}", Fp6::new([0, 1, 2, 0, 5, 23])),
             "u + 2u^2 + 5u^4 + 23u^5"
         );
+        assert_eq!(format!("{:?}", Fp6::new([0, 0, 0, 0, 0, 1])), "u^5");
 
         let a = Fp6::one().neg();
         assert_eq!(format!("{:?}", a), "18446744069414584320");
+
+        assert_eq!(format!("{:?}", Fp6::new([1, 1, 1, 1, 1, 1])), "1 + u + u^2 + u^3 + u^4 + u^5")
     }
 
     #[test]

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -56,6 +56,10 @@ pub struct Fp6 {
 
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        if self.is_zero().into() {
+            return write!(f, "0"); // Handle the case where all coefficients are zero
+        }
+
         let coeffs: [Fp; 6] = self.into();
 
         let format_term = |coef: Fp, degree: usize| -> String {
@@ -95,10 +99,6 @@ impl fmt::Debug for Fp6 {
             })
             .collect::<Vec<String>>()
             .join(" + ");
-
-        if self.is_zero().into() {
-            return write!(f, "0"); // Handle the case where all coefficients are zero
-        }
 
         write!(f, "{}", elem_rep)?;
 

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -84,7 +84,7 @@ impl fmt::Debug for Fp6 {
         }
 
         if first_term {
-            write!(f, "")?; // Handle the case where all coefficients are zero
+            write!(f, "0")?; // Handle the case where all coefficients are zero
         }
 
         Ok(())

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -56,11 +56,33 @@ pub struct Fp6 {
 
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{:?} + {:?}*u + {:?}*u^2 + {:?}*u^3 + {:?}*u^4 + {:?}*u^5",
-            self.c0, self.c1, self.c2, self.c3, self.c4, self.c5
-        )
+        let coeffs = [self.c0, self.c1, self.c2, self.c3, self.c4, self.c5];
+
+        for i in 0..6 {
+            if coeffs[i] == Fp::zero() {
+                continue;
+            }
+
+            let coefficient = format!("{}", coeffs[i]);
+
+            if i >= 1 {
+                if coeffs[i] != Fp::one() {
+                    write!(f, " + {}", coefficient)?
+                }
+
+                if i >= 1 {
+                    write!(f, "u")?;
+                }
+
+                if i >= 2 {
+                    write!(f, "^{}", i)?;
+                }
+            } else {
+                write!(f, "{coefficient}")?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1258,24 +1280,19 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        assert_eq!(
-            format!("{:?}", Fp6::zero()),
-            "0 + 0*u + 0*u^2 + 0*u^3 + 0*u^4 + 0*u^5"
-        );
-        assert_eq!(
-            format!("{:?}", Fp6::one()),
-            "1 + 0*u + 0*u^2 + 0*u^3 + 0*u^4 + 0*u^5"
-        );
+        assert_eq!(format!("{:?}", Fp6::one()), "1");
+        assert_eq!(format!("{:?}", Fp6::zero()), "");
         assert_eq!(
             format!("{:?}", Fp6::new([1, 2, 3, 4, 5, 6])),
-            "1 + 2*u + 3*u^2 + 4*u^3 + 5*u^4 + 6*u^5"
+            "1 + 2u + 3u^2 + 4u^3 + 5u^4 + 6u^5"
+        );
+        assert_eq!(
+            format!("{:?}", Fp6::new([0, 1, 2, 0, 5, 23])),
+            "u + 2u^2 + 5u^4 + 23u^5"
         );
 
         let a = Fp6::one().neg();
-        assert_eq!(
-            format!("{:?}", a),
-            "18446744069414584320 + 0*u + 0*u^2 + 0*u^3 + 0*u^4 + 0*u^5"
-        );
+        assert_eq!(format!("{:?}", a), "18446744069414584320");
     }
 
     #[test]

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -56,7 +56,7 @@ pub struct Fp6 {
 
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let coeffs = [self.c0, self.c1, self.c2, self.c3, self.c4, self.c5];
+        let coeffs: [Fp; 6] = self.into();
         let mut first_term = true;
         for i in 0..6 {
             if coeffs[i] == Fp::zero() {

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -89,11 +89,11 @@ impl fmt::Debug for Fp6 {
             .collect::<Vec<String>>()
             .join(" + ");
 
-        if elem_rep.is_empty() {
-            write!(f, "0")?; // Handle the case where all coefficients are zero
-        } else {
-            write!(f, "{}", elem_rep)?;
+        if self.is_zero().into() {
+            return write!(f, "0"); // Handle the case where all coefficients are zero
         }
+        
+        write!(f, "{}", elem_rep)?;
 
         Ok(())
     }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -17,6 +17,13 @@ use core::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use group::ff::Field;
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};


### PR DESCRIPTION
# Description

Changed debug format for Fp3 and Fp6 such that coeffs of zero and one are handled. 
Before the change, `Fp6::new([1, 0, 0, 1, 0, 1])` is formatted as `1 + 0 * u + 0 * u^2 + 1 * u^3 + 0 * u^4 + 1 * u^5`.

After the change, it is formatted as `1 + u^3 + u^5`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
